### PR TITLE
 Inclusão do status e tipo de rastreio BDI 14 dos Correios

### DIFF
--- a/correios/models/data.py
+++ b/correios/models/data.py
@@ -1098,6 +1098,12 @@ TRACKING_STATUS = {
         '',
         'Acionar atendimento dos Correios.',
     ),
+    ('BDI', 14): (
+        'returned',
+        'Desistência de postagem pelo remetente',
+        '',
+        'Acompanhar o retorno do objeto ao remetente.',
+    ),
     ('LDI', 14): (
         'waiting_retrieval',
         'Objeto aguardando retirada no endereço indicado',

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -473,7 +473,7 @@ class Package:
             raise exceptions.InvalidMaxPackageDimensionsError(msg)
 
     @classmethod
-    def _validate_weight(cls, weight, service: Optional[Union[Service, str, int]]=None) -> None:
+    def _validate_weight(cls, weight, service: Optional[Union[Service, str, int]] = None) -> None:
         if weight <= 0:
             raise exceptions.InvalidMinPackageWeightError("Invalid weight {!r}g".format(weight))
 
@@ -578,7 +578,7 @@ class ShippingLabel:
                  text: Optional[str] = "",
                  latitude: Optional[float] = 0.0,
                  longitude: Optional[float] = 0.0,
-                 receipt: Receipt=None) -> None:
+                 receipt: Receipt = None) -> None:
 
         if sender == receiver:
             raise exceptions.InvalidAddressesError("Sender and receiver cannot be the same")


### PR DESCRIPTION
Devido a algumas encomendas estarem retornando no rastreio o status `BDI 14 - Desistência de postagem pelo remetente` é necessário incluir dentro da aplicação para suprimir o erro.
