### PR TITLE
Quando o pacote não for do tipo cilíndrico, envia diametro 0.

### DIFF
--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -302,6 +302,8 @@ class Package:
 
     @property
     def diameter(self) -> int:
+        if self.package_type != Package.TYPE_CYLINDER:
+            return 0
         return max(MIN_DIAMETER, int(math.ceil(self.real_diameter)))
 
     @diameter.setter


### PR DESCRIPTION
Esta alteração visa mudar o valor `dimensao_diametro` para 0 quando não for enviado. Com o mínimo fica assim:

```xml
        <dimensao_objeto>
            <tipo_objeto>002</tipo_objeto>
            <dimensao_altura>57</dimensao_altura>
            <dimensao_largura>57</dimensao_largura>
            <dimensao_comprimento>72</dimensao_comprimento>
            <dimensao_diametro>16</dimensao_diametro>
        </dimensao_objeto>
``` 

Do jeito novo passaremos a enviar da seguinte forma:

```xml
<dimensao_objeto>
            <tipo_objeto>002</tipo_objeto>
            <dimensao_altura>57</dimensao_altura>
            <dimensao_largura>57</dimensao_largura>
            <dimensao_comprimento>72</dimensao_comprimento>
            <dimensao_diametro>0</dimensao_diametro>
        </dimensao_objeto>
```