### PR TITLE
STK370 - Adiciona novos service codes

### DIFF
--- a/correios/models/data.py
+++ b/correios/models/data.py
@@ -480,27 +480,71 @@ SERVICES = {
         'category': 'CARTA_REGISTRADA',
         'display_name': 'Carta Comercial',
     },
-    "04812": {
-        "id": 124899,
-        "description": "PAC CONTRATO - UO",
-        "category": "PAC",
-        "display_name": "PAC",
-        "max_weight": 30000,
-        "symbol": "standard",
-        "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
-        "max_declared_value": Decimal("3000.00"),
+    '04812': {
+        'id': 124899,
+        'description': 'PAC CONTRATO - UO',
+        'category': 'PAC',
+        'display_name': 'PAC',
+        'max_weight': 30000,
+        'symbol': 'standard',
+        'default_extra_services': [EXTRA_SERVICE_RR],
+        'min_declared_value': Decimal('19.50'),
+        'max_declared_value': Decimal('3000.00'),
     },
-    "04316": {
-        "id": 124900,
-        "description": "SEDEX CONTRATO - UO",
-        "category": "SEDEX",
-        "max_weight": 30000,
-        "display_name": "SEDEX",
-        "symbol": "express",
-        "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
-        "max_declared_value": Decimal("10000.00"),
+    '04316': {
+        'id': 124900,
+        'description': 'SEDEX CONTRATO - UO',
+        'category': 'SEDEX',
+        'max_weight': 30000,
+        'display_name': 'SEDEX',
+        'symbol': 'express',
+        'default_extra_services': [EXTRA_SERVICE_RR],
+        'min_declared_value': Decimal('19.50'),
+        'max_declared_value': Decimal('10000.00'),
+    },
+    '03298': {
+        'id': 124884,
+        'description': 'PAC',
+        'category': 'PAC',
+        'display_name': 'PAC',
+        'max_weight': 30000,
+        'symbol': "standard",
+        'default_extra_services': [EXTRA_SERVICE_RR],
+        'min_declared_value': Decimal("18.00"),
+        'max_declared_value': Decimal("3000.00"),
+    },
+    '03220': {
+        'id': 124849,
+        'description': 'SEDEX CONTRATO AGENCIA',
+        'category': 'SEDEX',
+        'max_weight': 30000,
+        'display_name': 'SEDEX',
+        'symbol': "express",
+        'default_extra_services': [EXTRA_SERVICE_RR],
+        'min_declared_value': Decimal("18.00"),
+        'max_declared_value': Decimal("10000.00"),
+    },
+    '03336': {
+        'id': 124899,
+        'description': 'PAC CONTRATO - UO',
+        'category': 'PAC',
+        'display_name': 'PAC',
+        'max_weight': 30000,
+        'symbol': 'standard',
+        'default_extra_services': [EXTRA_SERVICE_RR],
+        'min_declared_value': Decimal('19.50'),
+        'max_declared_value': Decimal('3000.00'),
+    },
+    '03280': {
+        'id': 124900,
+        'description': 'SEDEX CONTRATO - UO',
+        'category': 'SEDEX',
+        'max_weight': 30000,
+        'display_name': 'SEDEX',
+        'symbol': 'express',
+        'default_extra_services': [EXTRA_SERVICE_RR],
+        'min_declared_value': Decimal('19.50'),
+        'max_declared_value': Decimal('10000.00'),
     },
 }  # type: Dict[str, dict]
 
@@ -509,12 +553,12 @@ SERVICE_SEDEX = '04162'
 SERVICE_SEDEX10 = '40215'
 SERVICE_SEDEX12 = '40169'
 SERVICE_E_SEDEX = '81019'
-SERVICE_PAC_INDUSTRIAL = "04812"
-SERVICE_SEDEX_INDUSTRIAL = "04316"
+SERVICE_PAC_INDUSTRIAL = '04812'
+SERVICE_SEDEX_INDUSTRIAL = '04316'
 
-INSURANCE_VALUE_THRESHOLD_PAC = Decimal("50.00")  # R$
-INSURANCE_VALUE_THRESHOLD_SEDEX = Decimal("75.00")  # R$
-INSURANCE_PERCENTUAL_COST = Decimal("0.007")  # 0.7%
+INSURANCE_VALUE_THRESHOLD_PAC = Decimal('50.00')  # R$
+INSURANCE_VALUE_THRESHOLD_SEDEX = Decimal('75.00')  # R$
+INSURANCE_PERCENTUAL_COST = Decimal('0.007')  # 0.7%
 
 REGIONAL_DIRECTIONS = {
     1: {'code': "AC", 'name': "AC - ADMINISTRAÇAO CENTRAL"},


### PR DESCRIPTION
[CARD](https://luizalabs.swiftkanban.com/pui/index.jsp#projectid=75&itemid=STK370)

### Descrição

Inseridos os novos service codes do Correios, que substituirão os atuais.
- SEDEX - 03220
- PAC - 03298
- SEDEX INDUSTRIAL - 03280
- PAC INDUSTRIAL - 03336

-----------------------------------------------
- Eles foram inseridos apenas no dicionário `SERVICES`;
- Conforme testes integrados não é necessário alterar mais nada na lib Correios;
- Não houve necessidade de retirar os service codes atuais
- Não haviam os códigos de reversa atuais, portanto não coloquei os novos códigos de Reversa

#### Testes Integrados
- Criado ambiente de produção MLEntregas em localhost
- Modificados os service codes de 4 pedidos já existentes no banco sqlite
- Burladas as validações de service code no MLEntregas
- Inseridos 4 códigos de rastreio no banco sqlite, com os devidos códigos
- Etiquetas geradas

