### PR TITLE
STK492 - Updates the Display Adress to remove asterisk in the PLP

### DIFF
--- a/correios/models/address.py
+++ b/correios/models/address.py
@@ -315,7 +315,16 @@ class Address:
 
     @property
     def display_address(self) -> Tuple[str, str]:
-        address = "{}, {} - {}".format(self.street, self.raw_number, self.complement)
+        number = ""
+        complement = ""
+
+        if self.number:
+            number = ", {}".format(self.number)
+
+        if self.complement:
+            complement = " - {}".format(self.complement)
+
+        address = "{}{}{}".format(self.street, number, complement)
         city = "{} / {} - {}".format(self.city, self.state, self.zip_code.display())
         return address.strip(), city.strip()
 

--- a/tests/test_address_models.py
+++ b/tests/test_address_models.py
@@ -463,3 +463,30 @@ def test_custom_address_label_address_long_street_name(address_class):
     assert 'Vila' in address.label_address
     assert '1234' in address.label_address
     assert 'Ap 01' in address.label_address
+
+
+@pytest.mark.parametrize(
+    'street, number, complement, result', [
+        ('Rua Tiradentes, 199', '*', 'Ap 01', 'Rua Tiradentes, 199 - Ap 01'),
+        ('Rua Saudade', '222', 'Bloco C', 'Rua Saudade, 222 - Bloco C'),
+        ('Rua Guanabara, 111', '*', '', 'Rua Guanabara, 111')
+    ]
+)
+def test_should_remove_asterisk_from_display_address(
+    street,
+    number,
+    complement,
+    result
+):
+    address = Address(
+        name="Maria Moras",
+        street=street,
+        number=number,
+        city="Botelhos",
+        state="MG",
+        zip_code="37720-000",
+        neighborhood="Posto do Loyola",
+        complement=complement
+    )
+
+    assert address.display_address[0] == result


### PR DESCRIPTION
It was necessary to change the sender address in PLP to use the number with the asterisk removal filter.